### PR TITLE
Add support for "data" scheme to ImageLoaderManager

### DIFF
--- a/MdXaml/ImageLoaderManager.cs
+++ b/MdXaml/ImageLoaderManager.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Policy;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -136,6 +137,23 @@ namespace MdXaml
                     catch
                     {
                         return new Result<Stream>("resource not found");
+                    }
+                case "data":
+                    try
+                    {
+                        Regex dataRegex = new(@"\(data:image/(?:png|jpg|jpeg);base64,(?<data>[^\n|[]*)\).?");
+                        
+                        var match = dataRegex.Match(uri.AbsoluteUri);
+                        if(!match.Success)
+                            return new Result<Stream>("invalid format for scheme 'data'");
+                        
+                        var imageBytes = Convert.FromBase64String(match.Groups["data"].Value);
+
+                        return new Result<Stream>(new MemoryStream(imageBytes, false));
+                    }
+                    catch
+                    {
+                        return new Result<Stream>("invalid data");
                     }
             }
 

--- a/MdXaml/ImageLoaderManager.cs
+++ b/MdXaml/ImageLoaderManager.cs
@@ -141,9 +141,9 @@ namespace MdXaml
                 case "data":
                     try
                     {
-                        Regex dataRegex = new(@"\(data:image/(?:png|jpg|jpeg);base64,(?<data>[^\n|[]*)\).?");
+                        Regex dataRegex = new(@"data:image/(?:png|jpg|jpeg);base64,(?<data>[^\n|[]*)");
                         
-                        var match = dataRegex.Match(uri.AbsoluteUri);
+                        var match = dataRegex.Match(resourceUrl.AbsoluteUri);
                         if(!match.Success)
                             return new Result<Stream>("invalid format for scheme 'data'");
                         


### PR DESCRIPTION
This PR allows to load images which are given in a base64 format.

i.e.
`![Test](data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==)`