### PR TITLE
catch Uri exception

### DIFF
--- a/MdXaml/Markdown.cs
+++ b/MdXaml/Markdown.cs
@@ -601,7 +601,16 @@ namespace MdXaml
             string urlTxt = match.Groups[4].Value;
             string title = match.Groups[7].Value;
 
-            return LoadImage(linkText, urlTxt, title);
+            try
+            {
+                return LoadImage(linkText, urlTxt, title);
+            }
+            catch (Exception ex)
+            {
+                var errorRun = new Run($"Error: Can not load image from {urlTxt}, {ex.Message}");
+                errorRun.Foreground = Brushes.Red;
+                return errorRun;
+            }
         }
 
         private Inline ImageWithSizeEvaluator(Match match)


### PR DESCRIPTION
Load uri may throw exception when url has problem.

```
UriFormatException: Invalid URI: Failed to parse hostname
StackTrace:
   在 System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind)
   在 System.Uri.CreateUri(Uri baseUri, String relativeUri, Boolean dontEscape)
   在 MdXaml.Markdown.LoadImage(String tag, String urlTxt, String tooltipTxt, Action`3 onSuccess)
   在 MdXaml.Markdown.TreatsAsImage(Match match)
   在 MdXaml.SimpleInlineParser.Parser2.Parse(String text, Match firstMatch, IMarkdown engine, Int32& parseTextBegin, Int32& parseTextEnd)
   在 MdXaml.Markdown.RunSpanRest(String text, Int32 index, Int32 length, IInlineParser[] parsers, Int32 parserStart, List`1 outto)
   在 MdXaml.Markdown.PrivateRunSpanGamut(String text)
   在 MdXaml.Markdown.<FormParagraphs>d__150.MoveNext()
   在 System.Collections.Generic.List`1.InsertRange(Int32 index, IEnumerable`1 collection)
   在 MdXaml.Markdown.RunBlockRest(String text, Int32 index, Int32 length, Boolean supportTextAlignment, IBlockParser[] parsers, Int32 parserStart, List`1 outto)
   在 MdXaml.Markdown.PrivateRunBlockGamut(String text, Boolean supportTextAlignment)
   在 MdXaml.Markdown.Transform(String text)
   在 MdXaml.MarkdownScrollViewer.UpdateMarkdown(DependencyObject d, DependencyPropertyChangedEventArgs e)
   在 System.Windows.DependencyObject.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   在 System.Windows.FrameworkElement.OnPropertyChanged(DependencyPropertyChangedEventArgs e)
   在 System.Windows.DependencyObject.NotifyPropertyChange(DependencyPropertyChangedEventArgs args)
   在 System.Windows.DependencyObject.UpdateEffectiveValue(EntryIndex entryIndex, DependencyProperty dp, PropertyMetadata metadata, EffectiveValueEntry oldEntry, EffectiveValueEntry& newEntry, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType)
   在 System.Windows.DependencyObject.SetValueCommon(DependencyProperty dp, Object value, PropertyMetadata metadata, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType, Boolean isInternal)
   在 System.Windows.DependencyObject.SetValue(DependencyProperty dp, Object value)
   在 DynamicClass.MdViewerWrapper.<TextEditor_TextChanged>b__1()
   在 DynamicClass.DelayTriggerTimer.Timer_Tick(Object sender, EventArgs e)
   在 System.Windows.Threading.DispatcherTimer.FireTick(Object unused)
   在 System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   在 System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```