### PR TITLE
Fix dispatcher problems

### DIFF
--- a/MdXaml/ImageLoaderManager.cs
+++ b/MdXaml/ImageLoaderManager.cs
@@ -104,7 +104,7 @@ namespace MdXaml
             {
                 case "http":
                 case "https":
-                    var httpResult = await s_client.GetAsync(resourceUrl);
+                    var httpResult = await s_client.GetAsync(resourceUrl).ConfigureAwait(false);
                     if (httpResult.StatusCode == HttpStatusCode.OK)
                     {
                         var webstream = await httpResult.Content.ReadAsStreamAsync();

--- a/MdXaml/MarkdownScrollViewer.cs
+++ b/MdXaml/MarkdownScrollViewer.cs
@@ -59,10 +59,10 @@ namespace MdXaml
 
         public static readonly DependencyProperty MarkdownStyleNameProperty =
             DependencyProperty.Register(
-            nameof(MarkdownStyleName),
-            typeof(string),
-            typeof(MarkdownScrollViewer),
-            new PropertyMetadata(nameof(MdStyle.Standard), UpdateStyleName));
+                nameof(MarkdownStyleName),
+                typeof(string),
+                typeof(MarkdownScrollViewer),
+                new PropertyMetadata(nameof(MdStyle.Standard), UpdateStyleName));
 
         public static readonly DependencyProperty AssetPathRootProperty =
             DependencyProperty.Register(
@@ -70,6 +70,13 @@ namespace MdXaml
                 typeof(string),
                 typeof(MarkdownScrollViewer),
                 new PropertyMetadata(null, UpdateAssetPathRoot));
+
+        public static readonly DependencyProperty DisabledLazyLoadProperty =
+            DependencyProperty.Register(
+                nameof(DisabledLazyLoad),
+                typeof(bool),
+                typeof(MarkdownScrollViewer),
+                new PropertyMetadata(false, UpdateDisabledLazyLoad));
 
 
         private static void UpdateSource(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -159,6 +166,18 @@ namespace MdXaml
                 {
                     owner.Engine.AssetPathRoot = newPath;
                     UpdateMarkdown(d, e);
+                }
+            }
+        }
+
+        private static void UpdateDisabledLazyLoad(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if(d is MarkdownScrollViewer owner)
+            {
+                var disabledLazyLoad = (bool)e.NewValue;
+                if (disabledLazyLoad != owner.Engine.DisabledLazyLoad)
+                {
+                  owner.Engine.DisabledLazyLoad = (bool)e.NewValue;
                 }
             }
         }
@@ -303,6 +322,12 @@ namespace MdXaml
         {
             get { return (string)GetValue(MarkdownStyleNameProperty); }
             set { SetValue(MarkdownStyleNameProperty, value); }
+        }
+
+        public bool DisabledLazyLoad
+        {
+          get { return (bool)GetValue(DisabledLazyLoadProperty); }
+          set { SetValue(DisabledLazyLoadProperty, value); }
         }
 
         public Uri? Source


### PR DESCRIPTION
This library assumes that there is a single UI thread in the application. Therefore, Application.Current.Dispatcher gives you always access to the UI thread of your window and is therefore a sufficient solution when you want to have lazy loading for images. 
In our application however, we have multiple windows with their own UI thread and therefore their own dispatcher. To allow lazy loading we should be able to pass our own dispatcher to the library. This would require much more changes. So therefore we like be able to disable lazy loading and load images directly on the UI thread. Then we can apply any changes to the MarkdownScrollViewer via our own dispatcher.

For base64 images this fixed our problems. When testing images from an URL I found that the application would hang due to the GetAsync method of the HttpClient. It turned out that we had to apply ConfigureAwait(false) to run all code after the await on the same thread. This fixed the hanging application (deadlock). 

For reference, I work together with Luke Ordelmans who created a PR earlier on your project: [https://github.com/whistyun/MdXaml/pull/82](https://github.com/whistyun/MdXaml/pull/82)

**Please, if you agree with this change, then I would kindly ask you to create a new NuGet package as well.** 