### PR TITLE
Add 'HighlightOnly' ClickAction and fix incorrect command name.

### DIFF
--- a/MdXaml/LinkActions/DisplayCommand.cs
+++ b/MdXaml/LinkActions/DisplayCommand.cs
@@ -7,13 +7,13 @@ using MdXaml;
 namespace MdXaml.LinkActions
 {
     // set `public` access level for #29.
-    public class DiaplayCommand : ICommand
+    public class DisplayCommand : ICommand
     {
         private MarkdownScrollViewer Owner;
         private bool OpenBrowserWithAbsolutePath;
         private ICommand OpenCommand;
 
-        public DiaplayCommand(MarkdownScrollViewer owner, bool openBrowserWithAbsolutePath, bool safety)
+        public DisplayCommand(MarkdownScrollViewer owner, bool openBrowserWithAbsolutePath, bool safety)
         {
             Owner = owner;
             OpenBrowserWithAbsolutePath = openBrowserWithAbsolutePath;

--- a/MdXaml/LinkActions/HighlightOnlyCommand.cs
+++ b/MdXaml/LinkActions/HighlightOnlyCommand.cs
@@ -23,16 +23,6 @@ namespace MdXaml.LinkActions
 
         public bool CanExecute(object? parameter) => _isExecutable;
 
-        public void Execute(object? parameter)
-        {
-            //var path = parameter?.ToString();
-            //if (path is null) throw new ArgumentNullException(nameof(parameter));
-
-            //Process.Start(new ProcessStartInfo(path)
-            //{
-            //    UseShellExecute = true,
-            //    Verb = "open"
-            //});
-        }
+        public void Execute(object? parameter) {}
     }
 }

--- a/MdXaml/LinkActions/HighlightOnlyCommand.cs
+++ b/MdXaml/LinkActions/HighlightOnlyCommand.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace MdXaml.LinkActions
+{
+    public class HighlightOnlyCommand : ICommand
+    {
+        public event EventHandler? CanExecuteChanged;
+
+        private bool _isExecutable = true;
+        public bool IsExecutable
+        {
+            get => _isExecutable;
+            set
+            {
+                if (_isExecutable != value)
+                {
+                    _isExecutable = value;
+                    CanExecuteChanged?.Invoke(this, new EventArgs());
+                }
+            }
+        }
+
+        public bool CanExecute(object? parameter) => _isExecutable;
+
+        public void Execute(object? parameter)
+        {
+            //var path = parameter?.ToString();
+            //if (path is null) throw new ArgumentNullException(nameof(parameter));
+
+            //Process.Start(new ProcessStartInfo(path)
+            //{
+            //    UseShellExecute = true,
+            //    Verb = "open"
+            //});
+        }
+    }
+}

--- a/MdXaml/MarkdownScrollViewer.cs
+++ b/MdXaml/MarkdownScrollViewer.cs
@@ -459,8 +459,9 @@ namespace MdXaml
                     break;
 
                 case ClickAction.HighlightOnly:
-                    command = new HighlightOnlyCommand();
-                    break;
+                    Engine.HyperlinkCommand = new HighlightOnlyCommand();
+                    Engine.OnHyperLinkClicked = _onHyperLinkClicked;
+                    return;
 
                 default:
                     return;

--- a/MdXaml/MarkdownScrollViewer.cs
+++ b/MdXaml/MarkdownScrollViewer.cs
@@ -443,11 +443,11 @@ namespace MdXaml
                     break;
 
                 case ClickAction.DisplayWithRelativePath:
-                    command = new DiaplayCommand(this, true, false);
+                    command = new DisplayCommand(this, true, false);
                     break;
 
                 case ClickAction.DisplayAll:
-                    command = new DiaplayCommand(this, false, false);
+                    command = new DisplayCommand(this, false, false);
                     break;
 
                 case ClickAction.SafetyOpenBrowser:
@@ -455,7 +455,11 @@ namespace MdXaml
                     break;
 
                 case ClickAction.SafetyDisplayWithRelativePath:
-                    command = new DiaplayCommand(this, true, true);
+                    command = new DisplayCommand(this, true, true);
+                    break;
+
+                case ClickAction.HighlightOnly:
+                    command = new HighlightOnlyCommand();
                     break;
 
                 default:
@@ -641,6 +645,7 @@ namespace MdXaml
         DisplayAll,
         SafetyOpenBrowser,
         SafetyDisplayWithRelativePath,
+        HighlightOnly,
     }
 
     public enum SyntaxVersion


### PR DESCRIPTION
Hi there! One special option that I need is the link being highlighted and clickable, but without a function. This may be useful when we need to choose how to deal with different kinds of URIs. Please, take a loot at this PR and feel free to merge it :-)
