### PR TITLE
fix: add property into MdScrollViewer to edit DisableTooltip from engine

### DIFF
--- a/MdXaml/MarkdownScrollViewer.cs
+++ b/MdXaml/MarkdownScrollViewer.cs
@@ -376,6 +376,17 @@ namespace MdXaml
             }
         }
 
+        private bool _disableTooltip;
+        public bool DisableTooltip
+        {
+            get => _disableTooltip;
+            set
+            {
+                _disableTooltip = value;
+                Engine.DisabledTootip = _disableTooltip;
+            }
+        }
+
         public new FlowDocument? Document
         {
             get

--- a/samples/MdXaml.Demo2/MainWindow.xaml
+++ b/samples/MdXaml.Demo2/MainWindow.xaml
@@ -25,6 +25,7 @@
                     VerticalAlignment="Stretch"
                     HorizontalAlignment="Stretch"
                     ClickAction="DisplayWithRelativePath" OnHyperLinkClicked="OnLinkClicked"
+                    DisableTooltip="True"
                     Source="{Binding MdSource,Mode=TwoWay}" />
             </DockPanel>
         </TabItem>


### PR DESCRIPTION
Hi there! I noticed there's a "DisableTooltip" property in the engine, althought there isn't a way to edit it through MdScrollViewer.