### PR TITLE
Fixed highlight searching algorithm: prefer overridden highlights.

### DIFF
--- a/MdXaml/Highlighting/InternalHighlightManager.cs
+++ b/MdXaml/Highlighting/InternalHighlightManager.cs
@@ -122,8 +122,14 @@ namespace MdXaml.Highlighting
                 }
             }
 
-            return HighlightingManager.Instance.GetDefinitionByExtension("." + langcode)
-                ?? GetHighlight(langcode);
+            var r = GetHighlight(langcode);
+            if(r is not null)
+            {
+                return r;
+            }
+
+            return
+                HighlightingManager.Instance.GetDefinitionByExtension("." + langcode);
         }
 
         private IHighlightingDefinition? GetHighlight(string langcode)


### PR DESCRIPTION
Hi.

I found I can't change highlithing for `cs` alias, but I'm able to change highlight for `cshap` alias. This is very painful because both aliases means the same.

Looks like it is impossible via MdXaml: one can't override embedded in AvalonEdit highlight because `HighlightingManager.Instance` is checked before MdXaml's `IHighlightingDefinition? GetHighlight(string langcode)`.

I switched the order.

Looks like a potential breaking change, but I hope not a disaster.

What do you think? Will you accept this? If so, could you release a new version of nuget?