### PR TITLE
feat(Markdown.Style): 实现字体族绑定功能

### DIFF
--- a/MdXaml.SyntaxHigh/Markdown.Style.xaml
+++ b/MdXaml.SyntaxHigh/Markdown.Style.xaml
@@ -6,7 +6,7 @@
     xmlns:mdx="clr-namespace:MdXaml;assembly=MdXaml">
 
     <Style x:Key="DocumentStyleStandard" TargetType="FlowDocument">
-        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="PagePadding" Value="0" />
 
@@ -24,7 +24,7 @@
     </Style>
 
     <Style x:Key="DocumentStyleCompact" TargetType="FlowDocument">
-        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="PagePadding" Value="0" />
         <Setter Property="FontSize" Value="12" />
@@ -43,7 +43,7 @@
     </Style>
 
     <Style x:Key="DocumentStyleGithubLike" TargetType="FlowDocument">
-        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="PagePadding" Value="0" />
         <Setter Property="FontSize" Value="14" />
@@ -62,7 +62,7 @@
     <Style x:Key="DocumentStyleSasabune" TargetType="FlowDocument">
         <Setter Property="Background" Value="{mde:Alpha Background, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
 
-        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="PagePadding" Value="0" />
         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.1667, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
@@ -83,7 +83,7 @@
     <Style x:Key="DocumentStyleSasabuneStandard" TargetType="FlowDocument">
         <Setter Property="Background" Value="{mde:Alpha Background, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
 
-        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="PagePadding" Value="0" />
 
@@ -105,7 +105,7 @@
     <Style x:Key="DocumentStyleSasabuneCompact" TargetType="FlowDocument">
         <Setter Property="Background" Value="{mde:Alpha Background, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
 
-        <Setter Property="FontFamily" Value="Calibri" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="TextAlignment" Value="Left" />
         <Setter Property="PagePadding" Value="0" />
         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.0, TargetType={x:Type mdx:MarkdownScrollViewer}}" />

--- a/MdXaml/Markdown.Style.xaml
+++ b/MdXaml/Markdown.Style.xaml
@@ -1,14 +1,14 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:std="clr-namespace:System;assembly=mscorlib"
     xmlns:mde="clr-namespace:MdXaml.Ext"
-    xmlns:mdx="clr-namespace:MdXaml">
+    xmlns:mdx="clr-namespace:MdXaml"
+    xmlns:std="clr-namespace:System;assembly=mscorlib">
 
     <Style x:Key="DocumentStyleStandard" TargetType="FlowDocument">
-        <Setter Property="FontFamily" Value="Calibri" />
-        <Setter Property="TextAlignment" Value="Left" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="PagePadding" Value="0" />
+        <Setter Property="TextAlignment" Value="Left" />
 
         <Style.Resources>
             <std:String x:Key="MarkdownStyleName">DocumentStyleStandard</std:String>
@@ -16,9 +16,9 @@
             <Style TargetType="Section">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Blockquote">
-                        <Setter Property="Padding" Value="10,5" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="5,0,0,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -27,43 +27,43 @@
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Heading1">
                         <Setter Property="FontSize" Value="42" />
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="#ff000000" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading2">
                         <Setter Property="FontSize" Value="20" />
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="#ff000000" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading3">
                         <Setter Property="FontSize" Value="20" />
-                        <Setter Property="Foreground" Value="#99000000" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="#99000000" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading4">
                         <Setter Property="FontSize" Value="14" />
-                        <Setter Property="Foreground" Value="#99000000" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="#99000000" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="CodeBlock">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Background" Value="#EEEEEE" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="0,5,0,5" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Margin" Value="5,0,5,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Note">
-                        <Setter Property="Margin" Value="5,0,5,0" />
-                        <Setter Property="Padding" Value="10,5" />
+                        <Setter Property="Background" Value="#FAFAFA" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="3,3,3,3" />
-                        <Setter Property="Background" Value="#FAFAFA" />
+                        <Setter Property="Margin" Value="5,0,5,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
 
                 </Style.Triggers>
@@ -72,18 +72,18 @@
             <Style TargetType="Run">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Background" Value="#E0E0E0" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="DarkBlue" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
             <Style TargetType="Span">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Background" Value="#E0E0E0" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="DarkBlue" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -107,23 +107,23 @@
                 it looks like the ruled lines are not doubled.
             -->
             <Style TargetType="Table">
-                <Setter Property="CellSpacing" Value="0" />
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="Gray" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="CellSpacing" Value="0" />
             </Style>
 
             <Style TargetType="TableRowGroup">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="TableHeader">
-                        <Setter Property="FontWeight" Value="DemiBold" />
                         <Setter Property="Background" Value="LightGray" />
+                        <Setter Property="FontWeight" Value="DemiBold" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="TableCell">
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="Gray" />
+                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="Padding" Value="2" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TableRow}}, Path=Tag}" Value="EvenTableRow">
@@ -155,10 +155,10 @@
     </Style>
 
     <Style x:Key="DocumentStyleCompact" TargetType="FlowDocument">
-        <Setter Property="FontFamily" Value="Calibri" />
-        <Setter Property="TextAlignment" Value="Left" />
-        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="FontSize" Value="12" />
+        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="TextAlignment" Value="Left" />
 
         <Style.Resources>
             <std:String x:Key="MarkdownStyleName">DocumentStyleCompact</std:String>
@@ -166,9 +166,9 @@
             <Style TargetType="Section">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Blockquote">
-                        <Setter Property="Padding" Value="10,5" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="5,0,0,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -178,53 +178,53 @@
 
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Heading1">
-                        <Setter Property="Margin" Value="0,10,0,2" />
-
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontSize" Value="16" />
                         <Setter Property="FontWeight" Value="UltraBold" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="Margin" Value="0,10,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading2">
-                        <Setter Property="Margin" Value="0,10,0,2" />
-
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontSize" Value="14" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="Margin" Value="0,10,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading3">
-                        <Setter Property="Margin" Value="0,6,0,2" />
-
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontSize" Value="13" />
                         <Setter Property="FontWeight" Value="Light" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="Margin" Value="0,6,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading4">
-                        <Setter Property="Margin" Value="0,6,0,2" />
+                        <Setter Property="FontSize" Value="12" />
+                        <Setter Property="FontStyle" Value="Italic" />
+                        <Setter Property="FontWeight" Value="Light" />
 
                         <Setter Property="Foreground" Value="#aa000000" />
-                        <Setter Property="FontSize" Value="12" />
-                        <Setter Property="FontWeight" Value="Light" />
-                        <Setter Property="FontStyle" Value="Italic" />
+                        <Setter Property="Margin" Value="0,6,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="CodeBlock">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Background" Value="#EEEEEE" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="0,5,0,5" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Margin" Value="5,0,5,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Note">
-                        <Setter Property="Margin" Value="5,0,5,0" />
-                        <Setter Property="Padding" Value="10,5" />
+                        <Setter Property="Background" Value="#FAFAFA" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="3,3,3,3" />
-                        <Setter Property="Background" Value="#FAFAFA" />
+                        <Setter Property="Margin" Value="5,0,5,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -232,18 +232,18 @@
             <Style TargetType="Run">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Background" Value="#E0E0E0" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="DarkBlue" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
             <Style TargetType="Span">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="DarkBlue" />
                         <Setter Property="Background" Value="#E0E0E0" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="DarkBlue" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -271,23 +271,23 @@
                 it looks like the ruled lines are not doubled.
             -->
             <Style TargetType="Table">
-                <Setter Property="CellSpacing" Value="0" />
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="Gray" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="CellSpacing" Value="0" />
             </Style>
 
             <Style TargetType="TableRowGroup">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="TableHeader">
-                        <Setter Property="FontWeight" Value="DemiBold" />
                         <Setter Property="Background" Value="LightGray" />
+                        <Setter Property="FontWeight" Value="DemiBold" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="TableCell">
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="Gray" />
+                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="Padding" Value="1" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TableRow}}, Path=Tag}" Value="EvenTableRow">
@@ -319,10 +319,10 @@
     </Style>
 
     <Style x:Key="DocumentStyleGithubLike" TargetType="FlowDocument">
-        <Setter Property="FontFamily" Value="Calibri" />
-        <Setter Property="TextAlignment" Value="Left" />
-        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="FontSize" Value="14" />
+        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="TextAlignment" Value="Left" />
 
         <Style.Resources>
             <std:String x:Key="MarkdownStyleName">DocumentStyleGithubLike</std:String>
@@ -330,9 +330,9 @@
             <Style TargetType="Section">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Blockquote">
-                        <Setter Property="Padding" Value="10,5" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="5,0,0,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -342,50 +342,50 @@
 
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Heading1">
-                        <Setter Property="Margin" Value="0,0,15,0" />
-
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontSize" Value="28" />
                         <Setter Property="FontWeight" Value="UltraBold" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="Margin" Value="0,0,15,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading2">
-                        <Setter Property="Margin" Value="0,0,15,0" />
-
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontSize" Value="21" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="Margin" Value="0,0,15,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading3">
-                        <Setter Property="Margin" Value="0,0,10,0" />
-
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontSize" Value="17.5" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="Margin" Value="0,0,10,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading4">
-                        <Setter Property="Margin" Value="0,0,5,0" />
-
-                        <Setter Property="Foreground" Value="#ff000000" />
                         <Setter Property="FontSize" Value="14" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="#ff000000" />
+                        <Setter Property="Margin" Value="0,0,5,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="CodeBlock">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Background" Value="#12181F25" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Padding" Value="20,10" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Note">
-                        <Setter Property="Margin" Value="5,0,5,0" />
-                        <Setter Property="Padding" Value="10,5" />
+                        <Setter Property="Background" Value="#FAFAFA" />
                         <Setter Property="BorderBrush" Value="#DEDEDE" />
                         <Setter Property="BorderThickness" Value="3,3,3,3" />
-                        <Setter Property="Background" Value="#FAFAFA" />
+                        <Setter Property="Margin" Value="5,0,5,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
 
                 </Style.Triggers>
@@ -394,18 +394,18 @@
             <Style TargetType="Run">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Background" Value="#12181F25" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontSize" Value="11.9" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
             <Style TargetType="Span">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Background" Value="#12181F25" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontSize" Value="11.9" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -429,13 +429,13 @@
                 it looks like the ruled lines are not doubled.
             -->
             <Style TargetType="Table">
-                <Setter Property="CellSpacing" Value="0" />
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="#DFE2E5" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="CellSpacing" Value="0" />
                 <Style.Resources>
                     <Style TargetType="TableCell">
-                        <Setter Property="BorderThickness" Value="0.5" />
                         <Setter Property="BorderBrush" Value="#DFE2E5" />
+                        <Setter Property="BorderThickness" Value="0.5" />
                         <Setter Property="Padding" Value="13,6" />
                     </Style>
                 </Style.Resources>
@@ -444,9 +444,9 @@
             <Style TargetType="TableRowGroup">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="TableHeader">
+                        <Setter Property="Background" Value="#FFFFFF" />
                         <Setter Property="FontWeight" Value="DemiBold" />
                         <Setter Property="FontWeight" Value="Bold" />
-                        <Setter Property="Background" Value="#FFFFFF" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -484,10 +484,10 @@
     <Style x:Key="DocumentStyleSasabune" TargetType="FlowDocument">
         <Setter Property="Background" Value="{mde:Alpha Background, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
 
-        <Setter Property="FontFamily" Value="Calibri" />
-        <Setter Property="TextAlignment" Value="Left" />
-        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.1667, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="TextAlignment" Value="Left" />
 
         <Style.Resources>
             <std:String x:Key="MarkdownStyleName">DocumentStyleSasabune</std:String>
@@ -495,9 +495,9 @@
             <Style TargetType="Section">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Blockquote">
-                        <Setter Property="Padding" Value="10,5" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1839, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="5,0,0,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -507,50 +507,50 @@
 
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Heading1">
-                        <Setter Property="Margin" Value="0,0,15,0" />
-
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="28" />
                         <Setter Property="FontWeight" Value="UltraBold" />
+
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="0,0,15,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading2">
-                        <Setter Property="Margin" Value="0,0,15,0" />
-
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="21" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="0,0,15,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading3">
-                        <Setter Property="Margin" Value="0,0,10,0" />
-
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="17.5" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="0,0,10,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading4">
-                        <Setter Property="Margin" Value="0,0,5,0" />
-
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="14" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="0,0,5,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="CodeBlock">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Padding" Value="20,10" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Note">
-                        <Setter Property="Margin" Value="5,0,5,0" />
-                        <Setter Property="Padding" Value="10,5" />
+                        <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0196, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1294, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="3,3,3,3" />
-                        <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0196, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="5,0,5,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
 
                 </Style.Triggers>
@@ -559,25 +559,25 @@
             <Style TargetType="Run">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontSize" Value="11.9" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
             <Style TargetType="Span">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="FontSize" Value="11.9" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontSize" Value="11.9" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="Hyperlink">
-                <Setter Property="TextDecorations" Value="None" />
                 <Setter Property="Foreground" Value="{mde:Brightness Blue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="TextDecorations" Value="None" />
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="Foreground" Value="{mde:Brightness Red, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
@@ -600,13 +600,13 @@
                 it looks like the ruled lines are not doubled.
             -->
             <Style TargetType="Table">
-                <Setter Property="CellSpacing" Value="0" />
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.4980, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="CellSpacing" Value="0" />
                 <Style.Resources>
                     <Style TargetType="TableCell">
-                        <Setter Property="BorderThickness" Value="0.5" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.4980, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="BorderThickness" Value="0.5" />
                         <Setter Property="Padding" Value="13,6" />
                     </Style>
                 </Style.Resources>
@@ -654,9 +654,9 @@
     <Style x:Key="DocumentStyleSasabuneStandard" TargetType="FlowDocument">
         <Setter Property="Background" Value="{mde:Alpha Background, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
 
-        <Setter Property="FontFamily" Value="Calibri" />
-        <Setter Property="TextAlignment" Value="Left" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="PagePadding" Value="0" />
+        <Setter Property="TextAlignment" Value="Left" />
 
         <Style.Resources>
             <std:String x:Key="MarkdownStyleName">DocumentStyleSasabuneStandard</std:String>
@@ -664,9 +664,9 @@
             <Style TargetType="Section">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Blockquote">
-                        <Setter Property="Padding" Value="10,5" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1839, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="5,0,0,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -674,44 +674,44 @@
             <Style TargetType="Paragraph">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Heading1">
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="{mde:FontSizeScale 3.5, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading2">
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.6667, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading3">
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 0.7, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.6667, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 0.7, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading4">
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 0.7, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.1667, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontWeight" Value="Light" />
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 0.7, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="CodeBlock">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1839, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="0,5,0,5" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Margin" Value="5,0,5,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Note">
-                        <Setter Property="Margin" Value="5,0,5,0" />
-                        <Setter Property="Padding" Value="10,5" />
+                        <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1839, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="3,3,3,3" />
-                        <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="5,0,5,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
 
                 </Style.Triggers>
@@ -720,25 +720,25 @@
             <Style TargetType="Run">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
             <Style TargetType="Span">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="Hyperlink">
-                <Setter Property="TextDecorations" Value="None" />
                 <Setter Property="Foreground" Value="{mde:Brightness Blue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="TextDecorations" Value="None" />
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="Foreground" Value="{mde:Brightness Red, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
@@ -761,23 +761,23 @@
                 it looks like the ruled lines are not doubled.
             -->
             <Style TargetType="Table">
-                <Setter Property="CellSpacing" Value="0" />
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.4980, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="CellSpacing" Value="0" />
             </Style>
 
             <Style TargetType="TableRowGroup">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="TableHeader">
-                        <Setter Property="FontWeight" Value="DemiBold" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.1850, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontWeight" Value="DemiBold" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="TableCell">
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.4980, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="Padding" Value="2" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TableRow}}, Path=Tag}" Value="EvenTableRow">
@@ -811,10 +811,10 @@
     <Style x:Key="DocumentStyleSasabuneCompact" TargetType="FlowDocument">
         <Setter Property="Background" Value="{mde:Alpha Background, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
 
-        <Setter Property="FontFamily" Value="Calibri" />
-        <Setter Property="TextAlignment" Value="Left" />
-        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.0, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+        <Setter Property="PagePadding" Value="0" />
+        <Setter Property="TextAlignment" Value="Left" />
 
         <Style.Resources>
             <std:String x:Key="MarkdownStyleName">DocumentStyleSasabuneCompact</std:String>
@@ -822,9 +822,9 @@
             <Style TargetType="Section">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Blockquote">
-                        <Setter Property="Padding" Value="10,5" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1839, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="5,0,0,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -834,53 +834,53 @@
 
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="Heading1">
-                        <Setter Property="Margin" Value="0,10,0,2" />
-
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.3333, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontWeight" Value="UltraBold" />
+
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="0,10,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading2">
-                        <Setter Property="Margin" Value="0,10,0,2" />
-
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.1666, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontWeight" Value="Bold" />
+
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="0,10,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading3">
-                        <Setter Property="Margin" Value="0,6,0,2" />
-
-                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontSize" Value="{mde:FontSizeScale 1.083, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="FontWeight" Value="Light" />
+
+                        <Setter Property="Foreground" Value="{mde:Alpha Foreground, 1, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="0,6,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Heading4">
-                        <Setter Property="Margin" Value="0,6,0,2" />
+                        <Setter Property="FontSize" Value="{mde:FontSizeScale 1.0, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontStyle" Value="Italic" />
+                        <Setter Property="FontWeight" Value="Light" />
 
                         <Setter Property="Foreground" Value="{mde:Alpha Foreground, 0.7530, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
-                        <Setter Property="FontSize" Value="{mde:FontSizeScale 1.0, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
-                        <Setter Property="FontWeight" Value="Light" />
-                        <Setter Property="FontStyle" Value="Italic" />
+                        <Setter Property="Margin" Value="0,6,0,2" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="CodeBlock">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1839, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="0,5,0,5" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Margin" Value="5,0,5,0" />
                     </Trigger>
 
                     <Trigger Property="Tag" Value="Note">
-                        <Setter Property="Margin" Value="5,0,5,0" />
-                        <Setter Property="Padding" Value="10,5" />
+                        <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.1839, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="BorderThickness" Value="3,3,3,3" />
-                        <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Margin" Value="5,0,5,0" />
+                        <Setter Property="Padding" Value="10,5" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
@@ -888,25 +888,25 @@
             <Style TargetType="Run">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
             <Style TargetType="Span">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="CodeSpan">
-                        <Setter Property="FontFamily" Value="Courier New" />
-                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.0800, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontFamily" Value="{Binding FontFamily, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="Foreground" Value="{mde:Brightness DarkBlue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="Hyperlink">
-                <Setter Property="TextDecorations" Value="None" />
                 <Setter Property="Foreground" Value="{mde:Brightness Blue, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="TextDecorations" Value="None" />
                 <Style.Triggers>
                     <Trigger Property="IsMouseOver" Value="True">
                         <Setter Property="Foreground" Value="{mde:Brightness Red, Foreground, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
@@ -933,23 +933,23 @@
                 it looks like the ruled lines are not doubled.
             -->
             <Style TargetType="Table">
-                <Setter Property="CellSpacing" Value="0" />
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.4980, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="BorderThickness" Value="0.5" />
+                <Setter Property="CellSpacing" Value="0" />
             </Style>
 
             <Style TargetType="TableRowGroup">
                 <Style.Triggers>
                     <Trigger Property="Tag" Value="TableHeader">
-                        <Setter Property="FontWeight" Value="DemiBold" />
                         <Setter Property="Background" Value="{mde:Alpha Foreground, 0.1850, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                        <Setter Property="FontWeight" Value="DemiBold" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style TargetType="TableCell">
-                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="BorderBrush" Value="{mde:Alpha Foreground, 0.4980, TargetType={x:Type mdx:MarkdownScrollViewer}}" />
+                <Setter Property="BorderThickness" Value="0.5" />
                 <Setter Property="Padding" Value="1" />
                 <Style.Triggers>
                     <DataTrigger Binding="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type TableRow}}, Path=Tag}" Value="EvenTableRow">

--- a/samples/MdXaml.Demo/MainWindow.xaml
+++ b/samples/MdXaml.Demo/MainWindow.xaml
@@ -1,143 +1,182 @@
-<Window x:Class="MdXaml.Demo.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:mdxam="clr-namespace:MdXaml;assembly=MdXaml"
-        xmlns:mdmatter="clr-namespace:MdXaml.FrontMatter;assembly=MdXaml.FrontMatter"
-        xmlns:local="clr-namespace:MdXaml.Demo"
-        Title="MdXaml Demo"
-        Height="600"
-        Width="800" >
+<Window
+    x:Class="MdXaml.Demo.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:MdXaml.Demo"
+    xmlns:mdmatter="clr-namespace:MdXaml.FrontMatter;assembly=MdXaml.FrontMatter"
+    xmlns:mdxam="clr-namespace:MdXaml;assembly=MdXaml"
+    Title="MdXaml Demo"
+    Width="800"
+    Height="600">
 
     <Window.Resources>
-        <local:RGBConverter x:Key="Converter"/>
-        <local:MarkdownXamlConverter x:Key="MarkdownXamlConverter"/>
-        <local:FrontMatterDictToListConverter x:Key="FrontMatterDictToListConverter"/>
+        <local:RGBConverter x:Key="Converter" />
+        <local:MarkdownXamlConverter x:Key="MarkdownXamlConverter" />
+        <local:FrontMatterDictToListConverter x:Key="FrontMatterDictToListConverter" />
     </Window.Resources>
 
     <Window.DataContext>
-        <local:MainWindowViewModel/>
+        <local:MainWindowViewModel />
     </Window.DataContext>
 
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="*"/>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
         <TabControl x:Name="Inputs" Grid.Column="0">
             <TabItem Header="Markdown">
                 <TextBox
-                    VerticalAlignment="Stretch"
-                    HorizontalAlignment="Stretch"
-                    TextWrapping="Wrap"
-                    AcceptsReturn="True"
                     Margin="5"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
+                    AcceptsReturn="True"
                     Text="{Binding RawText, UpdateSourceTrigger=PropertyChanged}"
-                    VerticalScrollBarVisibility="Auto"/>
+                    TextWrapping="Wrap"
+                    VerticalScrollBarVisibility="Auto" />
             </TabItem>
             <TabItem Header="Color">
                 <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="60"/>
-                        <ColumnDefinition Width="100*"/>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="60" />
+                        <ColumnDefinition Width="100*" />
                     </Grid.ColumnDefinitions>
 
-                    <TextBlock Grid.Row="0" Grid.Column="0" Grid.RowSpan="3" VerticalAlignment="Center">Foreground</TextBlock>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.RowSpan="3"
+                        Grid.Column="0"
+                        VerticalAlignment="Center">
+                        Foreground
+                    </TextBlock>
                     <TextBlock Grid.Row="0" Grid.Column="1">R</TextBlock>
                     <TextBlock Grid.Row="1" Grid.Column="1">G</TextBlock>
                     <TextBlock Grid.Row="2" Grid.Column="1">B</TextBlock>
 
-                    <TextBox 
-                            Grid.Row="0" Grid.Column="2"
-                            Text="{Binding ForegroundRed}"/>
+                    <TextBox
+                        Grid.Row="0"
+                        Grid.Column="2"
+                        Text="{Binding ForegroundRed}" />
                     <Slider
-                            Grid.Row="0" Grid.Column="3"
-                            Minimum="0" Maximum="255"
-                            Value="{Binding ForegroundRed}"/>
+                        Grid.Row="0"
+                        Grid.Column="3"
+                        Maximum="255"
+                        Minimum="0"
+                        Value="{Binding ForegroundRed}" />
 
-                    <TextBox 
-                            Grid.Row="1" Grid.Column="2"
-                            Text="{Binding ForegroundGreen}"/>
+                    <TextBox
+                        Grid.Row="1"
+                        Grid.Column="2"
+                        Text="{Binding ForegroundGreen}" />
                     <Slider
-                            Grid.Row="1" Grid.Column="3"
-                            Minimum="0" Maximum="255" 
-                            Value="{Binding ForegroundGreen}"/>
+                        Grid.Row="1"
+                        Grid.Column="3"
+                        Maximum="255"
+                        Minimum="0"
+                        Value="{Binding ForegroundGreen}" />
 
-                    <TextBox 
-                            Grid.Row="2" Grid.Column="2"
-                            Text="{Binding ForegroundBlue}"/>
-                    <Slider 
-                            Grid.Row="2" Grid.Column="3" 
-                            Minimum="0" Maximum="255" 
-                            Value="{Binding ForegroundBlue}"/>
+                    <TextBox
+                        Grid.Row="2"
+                        Grid.Column="2"
+                        Text="{Binding ForegroundBlue}" />
+                    <Slider
+                        Grid.Row="2"
+                        Grid.Column="3"
+                        Maximum="255"
+                        Minimum="0"
+                        Value="{Binding ForegroundBlue}" />
 
-                    <Separator Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="4" Margin="0,8" />
+                    <Separator
+                        Grid.Row="3"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="4"
+                        Margin="0,8" />
 
-                    <TextBlock Grid.Row="4" Grid.Column="0" Grid.RowSpan="3" VerticalAlignment="Center">Background</TextBlock>
+                    <TextBlock
+                        Grid.Row="4"
+                        Grid.RowSpan="3"
+                        Grid.Column="0"
+                        VerticalAlignment="Center">
+                        Background
+                    </TextBlock>
                     <TextBlock Grid.Row="4" Grid.Column="1">R</TextBlock>
                     <TextBlock Grid.Row="5" Grid.Column="1">G</TextBlock>
                     <TextBlock Grid.Row="6" Grid.Column="1">B</TextBlock>
 
                     <TextBox
-                            Grid.Row="4" Grid.Column="2"
-                            Text="{Binding BackgroundRed}"/>
-                    <Slider 
-                            Grid.Row="4" Grid.Column="3"
-                            Minimum="0" Maximum="255"
-                            Value="{Binding BackgroundRed}"/>
+                        Grid.Row="4"
+                        Grid.Column="2"
+                        Text="{Binding BackgroundRed}" />
+                    <Slider
+                        Grid.Row="4"
+                        Grid.Column="3"
+                        Maximum="255"
+                        Minimum="0"
+                        Value="{Binding BackgroundRed}" />
 
                     <TextBox
-                            Grid.Row="5" Grid.Column="2"
-                            Text="{Binding BackgroundGreen}"/>
+                        Grid.Row="5"
+                        Grid.Column="2"
+                        Text="{Binding BackgroundGreen}" />
                     <Slider
-                            Grid.Row="5" Grid.Column="3"
-                            Minimum="0" Maximum="255"
-                            Value="{Binding BackgroundGreen}"/>
+                        Grid.Row="5"
+                        Grid.Column="3"
+                        Maximum="255"
+                        Minimum="0"
+                        Value="{Binding BackgroundGreen}" />
 
                     <TextBox
-                            Grid.Row="6" Grid.Column="2"
-                            Text="{Binding BackgroundBlue}"/>
+                        Grid.Row="6"
+                        Grid.Column="2"
+                        Text="{Binding BackgroundBlue}" />
                     <Slider
-                            Grid.Row="6" Grid.Column="3"
-                            Minimum="0" Maximum="255"
-                            Value="{Binding BackgroundBlue}"/>
+                        Grid.Row="6"
+                        Grid.Column="3"
+                        Maximum="255"
+                        Minimum="0"
+                        Value="{Binding BackgroundBlue}" />
                 </Grid>
             </TabItem>
         </TabControl>
-        <TabControl x:Name="Outputs" Grid.Column="1" SelectedIndex="{Binding ActiveTabIndex, Mode=TwoWay}">
+        <TabControl
+            x:Name="Outputs"
+            Grid.Column="1"
+            SelectedIndex="{Binding ActiveTabIndex, Mode=TwoWay}">
             <TabItem Header="View">
                 <DockPanel LastChildFill="True">
                     <ComboBox
                         DockPanel.Dock="Top"
-                        SelectedItem="{Binding SelectedStyleInfo}"
-                        ItemsSource="{Binding Styles}">
+                        ItemsSource="{Binding Styles}"
+                        SelectedItem="{Binding SelectedStyleInfo}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Name}"/>
+                                <TextBlock Text="{Binding Name}" />
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
 
-                    <mdxam:MarkdownScrollViewer x:Name="MarkdownViewer"
-                        VerticalAlignment="Stretch"
-                        HorizontalAlignment="Stretch"
+                    <mdxam:MarkdownScrollViewer
+                        x:Name="MarkdownViewer"
                         Margin="5"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
                         ClickAction="SafetyDisplayWithRelativePath"
                         Document="{Binding RenderingDocument, Mode=OneWayToSource}"
-                        MarkdownStyle="{Binding SelectedStyleInfo.Style}"
+                        FontFamily="Microsoft YaHei UI"
                         Markdown="{Binding RawText}"
-                    >
+                        MarkdownStyle="{Binding SelectedStyleInfo.Style}">
                         <mdxam:MarkdownScrollViewer.Foreground>
                             <MultiBinding Converter="{StaticResource Converter}">
                                 <Binding Path="ForegroundRed" />
@@ -158,22 +197,26 @@
 
             <TabItem Header="Xaml">
                 <TextBox
+                    Margin="5"
                     AcceptsReturn="True"
-                    Margin="5" 
-                    IsReadOnly="True"
                     HorizontalScrollBarVisibility="Auto"
-                    VerticalScrollBarVisibility="Auto"
-                    Text="{Binding Path=RequestingConvertXaml, Converter={StaticResource MarkdownXamlConverter}}">
-                </TextBox>
+                    IsReadOnly="True"
+                    Text="{Binding Path=RequestingConvertXaml, Converter={StaticResource MarkdownXamlConverter}}"
+                    VerticalScrollBarVisibility="Auto" />
             </TabItem>
 
             <TabItem Header="FrontMatter">
-                <ListView Margin="5"
-                    ItemsSource="{Binding RequestingConvertMatter.(mdmatter:FrontMatter.FrontMatterDic), Converter={StaticResource FrontMatterDictToListConverter}}">
+                <ListView Margin="5" ItemsSource="{Binding RequestingConvertMatter.(mdmatter:FrontMatter.FrontMatterDic), Converter={StaticResource FrontMatterDictToListConverter}}">
                     <ListView.View>
                         <GridView>
-                            <GridViewColumn Header="Key" DisplayMemberBinding="{Binding Key}" Width="180"/>
-                            <GridViewColumn Header="Value" DisplayMemberBinding="{Binding Value}" Width="400"/>
+                            <GridViewColumn
+                                Width="180"
+                                DisplayMemberBinding="{Binding Key}"
+                                Header="Key" />
+                            <GridViewColumn
+                                Width="400"
+                                DisplayMemberBinding="{Binding Value}"
+                                Header="Value" />
                         </GridView>
                     </ListView.View>
                 </ListView>

--- a/samples/WithFluentWPF/MainWindow.xaml
+++ b/samples/WithFluentWPF/MainWindow.xaml
@@ -1,14 +1,16 @@
-﻿<fw:AcrylicWindow  x:Class="WithFluentWPF.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:fw="clr-namespace:SourceChord.FluentWPF;assembly=FluentWPF"
-        xmlns:mdxam="clr-namespace:MdXaml;assembly=MdXaml"
-        xmlns:local="clr-namespace:WithFluentWPF"
-        mc:Ignorable="d"
-        
-        Title="MainWindow" Height="450" Width="800">
+﻿<fw:AcrylicWindow
+    x:Class="WithFluentWPF.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:fw="clr-namespace:SourceChord.FluentWPF;assembly=FluentWPF"
+    xmlns:local="clr-namespace:WithFluentWPF"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:mdxam="clr-namespace:MdXaml;assembly=MdXaml"
+    Title="MainWindow"
+    Width="800"
+    Height="450"
+    mc:Ignorable="d">
 
     <fw:AcrylicWindow.DataContext>
         <local:MainWindowViewModel />
@@ -16,8 +18,8 @@
 
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -25,39 +27,42 @@
         </Grid.ColumnDefinitions>
 
         <ComboBox
-                    Grid.Row="0" Grid.Column="0"
-                    Grid.ColumnSpan="2"
-                    SelectedItem="{Binding SelectedStyleInfo}"
-                    ItemsSource="{Binding Styles}">
+            Grid.Row="0"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            ItemsSource="{Binding Styles}"
+            SelectedItem="{Binding SelectedStyleInfo}">
 
             <ComboBox.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Text="{Binding Name}"/>
+                    <TextBlock Text="{Binding Name}" />
                 </DataTemplate>
             </ComboBox.ItemTemplate>
 
         </ComboBox>
 
         <TextBox
-                    Grid.Row="1" Grid.Column="0"
-                    VerticalAlignment="Stretch"
-                    HorizontalAlignment="Stretch"
-                    TextWrapping="Wrap"
-                    AcceptsReturn="True"
-                    Margin="5" 
-                    Text="{Binding TextView, UpdateSourceTrigger=PropertyChanged}"
-                    VerticalScrollBarVisibility="Auto"/>
+            Grid.Row="1"
+            Grid.Column="0"
+            Margin="5"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            AcceptsReturn="True"
+            Text="{Binding TextView, UpdateSourceTrigger=PropertyChanged}"
+            TextWrapping="Wrap"
+            VerticalScrollBarVisibility="Auto" />
 
         <mdxam:MarkdownScrollViewer
-                    Grid.Row="1" Grid.Column="1"
-                    VerticalAlignment="Stretch"
-                    HorizontalAlignment="Stretch"
-                    Background="{DynamicResource SystemAltHighColorBrush}"
-                    Margin="5"
-                    MarkdownStyle="{Binding SelectedStyleInfo.Style}"
-                    ClickAction="OpenBrowser"
-                    Markdown="{Binding TextView}"
-                     />
+            Grid.Row="1"
+            Grid.Column="1"
+            Margin="5"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            Background="{DynamicResource SystemAltHighColorBrush}"
+            ClickAction="OpenBrowser"
+            FontFamily="Microsoft YaHei UI"
+            Markdown="{Binding TextView}"
+            MarkdownStyle="{Binding SelectedStyleInfo.Style}" />
 
     </Grid>
 </fw:AcrylicWindow>


### PR DESCRIPTION
将所有文档样式的字体族从固定值 "Calibri" 、“Courier New”更改为动态绑定，
使其能够继承父级 MarkdownScrollViewer 控件的 FontFamily 属性，
从而实现更好的主题一致性和自定义能力